### PR TITLE
fix: warning empty contunuation line and remove pdo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN \
     # ENV variables
     PECL_EXTENSIONS="xdebug-2.5.5"; \
     PHP_EXTENSIONS="mysqli opcache zip pdo_mysql intl"; \
-    DEV_DEPS="libicu-dev g++"; \
+    DEV_DEPS="g++"; \
     # update package list
       apt-get update -qqy \
     # install
@@ -16,6 +16,7 @@ RUN \
     git \
     nodejs \
     npm \
+    libicu-dev \
     zlibc \
     zlib1g \
     zlib1g-dev \
@@ -41,7 +42,3 @@ RUN \
       && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/* /usr/share/man/*
 
 WORKDIR /var/www/project
-
-# Prevent container from immediately exit
-CMD tail -f /dev/null
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ RUN \
     # ENV variables
     PECL_EXTENSIONS="xdebug-2.5.5"; \
     PHP_EXTENSIONS="mysqli opcache zip pdo_mysql intl"; \
-    DEV_DEPS="g++"; \
+    DEV_DEPS="libicu-dev zlibc zlib1g zlib1g-dev"; \
+    TMP_DEV_DEPS="g++"; \
     # update package list
       apt-get update -qqy \
     # install
@@ -16,12 +17,10 @@ RUN \
     git \
     nodejs \
     npm \
-    libicu-dev \
-    zlibc \
-    zlib1g \
-    zlib1g-dev \
-    # install dev tools required by some php extensions
+    # dev dependencies which still persist after the build process
     $DEV_DEPS \
+    # temp dev dependencies which will be deleted at the end of the build process
+    $TMP_DEV_DEPS \
     # php + pecl extensions
     && docker-php-source extract \
       && pecl channel-update pecl.php.net \
@@ -35,7 +34,7 @@ RUN \
     && ln -sf /dev/stderr /var/log/php7.1-fpm.log \
     && ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone \
     # cleanup
-    && apt-get purge -y --auto-remove $DEV_DEPS \
+    && apt-get purge -y --auto-remove $TMP_DEV_DEPS \
       && apt-get clean \
       && apt-get autoclean \
       && apt-get autoremove \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ ENV TZ=Asia/Bangkok
 RUN \
     # ENV variables
     PECL_EXTENSIONS="xdebug-2.5.5"; \
-    PHP_EXTENSIONS="mysqli opcache pdo zip pdo_mysql intl"; \
+    PHP_EXTENSIONS="mysqli opcache zip pdo_mysql intl"; \
+    DEV_DEPS="libicu-dev g++"; \
     # update package list
       apt-get update -qqy \
     # install
@@ -18,6 +19,8 @@ RUN \
     zlibc \
     zlib1g \
     zlib1g-dev \
+    # install dev tools required by some php extensions
+    $DEV_DEPS \
     # php + pecl extensions
     && docker-php-source extract \
       && pecl channel-update pecl.php.net \
@@ -41,3 +44,4 @@ WORKDIR /var/www/project
 
 # Prevent container from immediately exit
 CMD tail -f /dev/null
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,22 +8,16 @@ RUN \
     # ENV variables
     PECL_EXTENSIONS="xdebug-2.5.5"; \
     PHP_EXTENSIONS="mysqli opcache pdo zip pdo_mysql intl"; \
-
     # update package list
       apt-get update -qqy \
     # install
     && apt-get -qqy --fix-missing --no-install-recommends install \
-
     git \
-
     nodejs \
-
     npm \
-
     zlibc \
     zlib1g \
     zlib1g-dev \
-
     # php + pecl extensions
     && docker-php-source extract \
       && pecl channel-update pecl.php.net \
@@ -31,14 +25,11 @@ RUN \
       && docker-php-ext-install $PHP_EXTENSIONS \
       && docker-php-ext-enable `echo $PECL_EXTENSIONS | sed -e "s/[^a-z ]//g"` \
       && docker-php-source delete \
-
     # composer
     && curl -sSL https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-
     # capture std error
     && ln -sf /dev/stderr /var/log/php7.1-fpm.log \
     && ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone \
-
     # cleanup
     && apt-get purge -y --auto-remove $DEV_DEPS \
       && apt-get clean \


### PR DESCRIPTION
fixed:
- remove empty line since docker does not allow empty line anymore
- bad gateway due to `tail` command in php-fpm container

cleanup:
- remove pdo since it has been included in other dependencies
- move dev dependencies into variables